### PR TITLE
BE-0008 feat: Add Docker support with Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Multi-stage build for a small final image
+
+# Builder stage (Debian-based for CGO)
+FROM golang:1.23-bookworm AS builder
+
+WORKDIR /app
+
+# Install build tools for CGO
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  git \
+  && rm -rf /var/lib/apt/lists/* \
+  && update-ca-certificates
+
+# Cache deps
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build binary with CGO for sqlite
+RUN CGO_ENABLED=1 go build -tags 'sqlite_omit_load_extension' -ldflags='-s -w' -o /bin/golang-todo-api ./cmd/server
+
+# Runtime stage (non-static, includes glibc)
+FROM gcr.io/distroless/base-debian12:nonroot
+
+WORKDIR /
+
+# Create app directories
+USER nonroot:nonroot
+
+# Copy binary from builder
+COPY --from=builder /bin/golang-todo-api /golang-todo-api
+
+# Expose default port
+EXPOSE 8080
+
+# Default envs (can be overridden)
+ENV PORT=8080 \
+  HOST=0.0.0.0 \
+  DATABASE_URL=/data/app.db
+
+# Create data volume for sqlite file
+VOLUME ["/data"]
+
+# Run the server
+ENTRYPOINT ["/golang-todo-api"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: golang-todo-api:local
+    container_name: golang-todo-api
+    environment:
+      - PORT=8080
+      - HOST=0.0.0.0
+      - DATABASE_URL=/data/app.db
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./data:/data
+    restart: unless-stopped


### PR DESCRIPTION
- Introduced Dockerfile for multi-stage build of the Go application.
- Added docker-compose.yml to define service configuration for the API.
- Configured environment variables, port mapping, and volume for data persistence.