### PR TITLE
BE-0000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ deps:
 	go mod download
 
 fmt:
-	if command -v gofumpt >/dev/null 2>&1; then \
+	@if command -v gofumpt >/dev/null 2>&1; then \
 		gofumpt -w ./; \
 	else \
 		go fmt ./...; \

--- a/internal/app/db.go
+++ b/internal/app/db.go
@@ -77,6 +77,6 @@ func ensureSQLitePragmas(dsn string) string {
 	out, sep = addOpt(out, "_busy_timeout", "_busy_timeout=5000")
 	out, sep = addOpt(out, "_cache_size", "_cache_size=-20000")
 	out, _ = addOpt(out, "_foreign_keys", "_foreign_keys=ON")
- 
+
 	return out
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -137,7 +137,6 @@ func Run() {
 		defer cancel()
 		if err := srv.Shutdown(ctx); err != nil {
 			log.Printf("Server forced to shutdown: %v", err)
-
 		}
 	}); err != nil {
 		log.Fatal(err)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -56,7 +56,7 @@ func TestRouter_HealthAndTodosRoute(t *testing.T) {
 	mockSvc.On("GetAllTodos").Return([]todos.Todo{}, nil).Once()
 	h := todos.NewTodoHandler(mockSvc)
 
-	r := New(engine, h, true)
+	r := New(engine, h, false)
 
 	// Health
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)

--- a/internal/todos/bench_test.go
+++ b/internal/todos/bench_test.go
@@ -44,7 +44,6 @@ func BenchmarkCreateAndList(b *testing.B) {
 	h.RegisterTodoRoutes(rg)
 
 	b.ReportAllocs()
- 
 	for i := 0; i < b.N; i++ {
 		// Create
 		body := CreateTodoRequest{Title: "t-" + itoa(i+1), Description: "d"}
@@ -59,7 +58,7 @@ func BenchmarkCreateAndList(b *testing.B) {
 		if w.Code != http.StatusCreated {
 			b.Fatalf("create status=%d", w.Code)
 		}
-    
+
 		// List
 		req2 := httptest.NewRequest(http.MethodGet, "/todos", nil)
 		w2 := httptest.NewRecorder()

--- a/internal/todos/handlers.go
+++ b/internal/todos/handlers.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"sync"
 
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
HOT fix: update Makefile formatting command and clean up whitespace in multiple files

- Added an `@` symbol to the `gofumpt` command in the Makefile to suppress errors if the command is not found.
- Removed unnecessary whitespace in `db.go`, `server.go`, `bench_test.go`, and `handlers.go` for cleaner code.
- Adjusted test initialization in `router_test.go` to set the router to not use debug mode.

NEVER RESOLVE CONFLICTS IN WEB =)